### PR TITLE
added realmModelSelected and model(at:) functions

### DIFF
--- a/Pod/Classes/Reactive+RxRealmDataSources.swift
+++ b/Pod/Classes/Reactive+RxRealmDataSources.swift
@@ -29,6 +29,20 @@ extension Reactive where Base: UITableView {
                 ds.applyChanges(items: AnyRealmCollection<E>(results), changes: changes)
             }
     }
+	
+	public func realmModelSelected<E>(_ modelType: E.Type) -> ControlEvent<E> where E: RealmSwift.Object {
+		
+		let source: Observable<E> = self.itemSelected.flatMap { [weak view = self.base as UITableView] indexPath -> Observable<E> in
+			guard let view = view, let ds = view.dataSource as? RxTableViewRealmDataSource<E> else {
+				return Observable.empty()
+			}
+			
+			return Observable.just(ds.model(at: indexPath))
+		}
+		
+		return ControlEvent(events: source)
+	}
+
 }
 
 extension Reactive where Base: UICollectionView {

--- a/Pod/Classes/RxTableViewRealmDataSource.swift
+++ b/Pod/Classes/RxTableViewRealmDataSource.swift
@@ -53,6 +53,10 @@ import RxRealm
                 return cell
             }
         }
+			
+			public func model(at indexPath: IndexPath) -> E {
+				return items![indexPath.row]
+			}
 
         // MARK: - UITableViewDataSource protocol
         public func numberOfSections(in tableView: UITableView) -> Int {


### PR DESCRIPTION
Allows for binding the selected realm object at an index path of an RXRealmDataSource driven table view