### PR TITLE
chore: update dependency and ios.deployment_target

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,14 +1,11 @@
 use_frameworks!
 
 abstract_target 'Demo' do
-  pod 'RealmSwift', '~> 5.1'
-  pod 'RxSwift', '~> 5.1'
-  pod 'RxCocoa', '~> 5.1'
-  pod 'RxRealm', '~> 3.0'
+
   pod 'RxRealmDataSources', :path => '../'
 
   target 'RxRealmDataSources_Example' do
-    platform :ios, '9.0'
+    platform :ios, '11.0'
   end
 
   target 'RxRealmDataSources_MacExample' do

--- a/RxRealmDataSources.podspec
+++ b/RxRealmDataSources.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name             = 'RxRealmDataSources'
-  s.version          = '0.3'
+  s.version          = '0.4'
   s.summary          = 'Rx data sources for RxRealm`s observable types'
 
   s.description      = <<-DESC
@@ -16,15 +16,15 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.12'
 
   s.source_files = 'Pod/Classes/*.swift'
 
   s.frameworks = 'Foundation'
 
-  s.dependency 'RealmSwift', '~> 5.1'
-  s.dependency 'RxSwift',    '~> 5.1'
-  s.dependency 'RxCocoa',    '~> 5.1'
-  s.dependency 'RxRealm',    '~> 3.0'
+  s.dependency 'RealmSwift', '~> 10.0'
+  s.dependency 'RxSwift',    '~> 6.0'
+  s.dependency 'RxCocoa',    '~> 6.0'
+  s.dependency 'RxRealm',    '~> 5.0'
 end


### PR DESCRIPTION
`ios.deployment_target` from `9.0` to `11.0`

dependency:
`RealmSwift` from `~> 5.1` to `~> 10.0`
`RxSwift` from `~> 5.1` to `~> 6.0`
`RxCocoa` from `~> 5.1` to `~> 6.0`
`RxRealm` from `~> 3.0` to `~> 5.0`